### PR TITLE
feature/improved-finalisation-message

### DIFF
--- a/.setup/scripts/999-finalise.sh
+++ b/.setup/scripts/999-finalise.sh
@@ -5,8 +5,15 @@ set -e
 
 # Echo messages to the user
 echo
-echo -e "${GREEN}Setup complete! Note that you may need to set your Git username and email if you are committing changes within this devcontainer.${NC}"
-echo -e "${GREEN}You can do this by running the following commands:${NC}"
-echo -e "${YELLOW}git config --global user.name 'Your Name'${NC}"
-echo -e "${YELLOW}git config --global user.email 'you@example.com'${NC}"
+echo -e "${GREEN}Setup complete!${NC}"
+
+# Check if git username and email are set
+GIT_NAME=$(git config --global user.name)
+GIT_EMAIL=$(git config --global user.email)
+if [[ -z "$GIT_NAME" || -z "$GIT_EMAIL" ]]; then
+  echo -e "${GREEN}Note that you may need to set your Git username and email if you are committing changes within this devcontainer.${NC}"
+  echo -e "${GREEN}You can do this by running the following commands:${NC}"
+  echo -e "${YELLOW}git config --global user.name 'Your Name'${NC}"
+  echo -e "${YELLOW}git config --global user.email 'you@example.com'${NC}"
+fi
 echo

--- a/.setup/scripts/999-finalise.sh
+++ b/.setup/scripts/999-finalise.sh
@@ -6,14 +6,15 @@ set -e
 # Echo messages to the user
 echo
 echo -e "${GREEN}Setup complete!${NC}"
+echo
 
 # Check if git username and email are set
-GIT_NAME=$(git config --global user.name)
-GIT_EMAIL=$(git config --global user.email)
+GIT_NAME=$(git config --global user.name || true)
+GIT_EMAIL=$(git config --global user.email || true)
 if [[ -z "$GIT_NAME" || -z "$GIT_EMAIL" ]]; then
   echo -e "${GREEN}Note that you may need to set your Git username and email if you are committing changes within this devcontainer.${NC}"
   echo -e "${GREEN}You can do this by running the following commands:${NC}"
   echo -e "${YELLOW}git config --global user.name 'Your Name'${NC}"
   echo -e "${YELLOW}git config --global user.email 'you@example.com'${NC}"
 fi
-echo
+echos


### PR DESCRIPTION
This pull request improves the user experience of the setup script by making the instructions for setting Git username and email conditional, so they are only shown when needed.

Improvements to setup script messaging:

* Modified `.setup/scripts/999-finalise.sh` to check if the global Git username and email are set, and only display instructions for setting them if they are missing. This avoids unnecessary information for users who already have their Git configuration set.